### PR TITLE
Patch required name field for provider-github

### DIFF
--- a/apis/composition.yaml
+++ b/apis/composition.yaml
@@ -102,6 +102,8 @@ spec:
       patches:
         - fromFieldPath: spec.parameters.marketplace.repo
           toFieldPath: metadata.annotations[crossplane.io/external-name]
+        - fromFieldPath: spec.parameters.github.repo
+          toFieldPath: spec.forProvider.name
 
     - name: githubActionSecretXPKGToken
       base:


### PR DESCRIPTION
<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

The repository name is a [required](https://github.com/coopnorge/provider-github/blob/main/package/crds/repo.github.upbound.io_repositories.yaml#L690-L691) field in the provider CRD, so this fixes the warning event 

```
[Repository.repo.github.upbound.io](http://repository.repo.github.upbound.io/) "provider-cloudflare-9qcvg-s4fdj" is invalid: spec: Invalid value: "object": spec.forProvider.name is a required parameter
```

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

In Upbound :D 
